### PR TITLE
Added missing requirement for rexml

### DIFF
--- a/tetra.gemspec
+++ b/tetra.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "clamp"
   s.add_runtime_dependency "json_pure"
   s.add_runtime_dependency "open4"
+  s.add_runtime_dependency "rexml"
   s.add_runtime_dependency "rubyzip", ">= 1.0"
   s.add_runtime_dependency "text"
 end


### PR DESCRIPTION
On AlmaLinux 9, tetra is missing the dependency rexml whilst it does not seem to be required on other operating systems.

Adding the dependency for completeness.