### PR TITLE
Update gemspec and fix #52

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,66 +1,110 @@
 PATH
   remote: .
   specs:
-    tetra (2.0.5)
+    tetra (2.0.6)
       clamp
+      erb (~> 2.2.3)
       json_pure
       open4
+      rexml
       rubyzip (>= 1.0)
       text
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     aruba (0.6.2)
       childprocess (>= 0.3.6)
       cucumber (>= 1.1.1)
       rspec-expectations (>= 2.7.0)
-    builder (3.2.2)
-    childprocess (0.5.6)
-      ffi (~> 1.0, >= 1.0.11)
-    clamp (1.3.1)
-    cucumber (2.0.0)
-      builder (>= 2.1.2)
-      cucumber-core (~> 1.1.3)
-      diff-lcs (>= 1.1.3)
-      gherkin (~> 2.12)
-      multi_json (>= 1.7.5, < 2.0)
-      multi_test (>= 0.1.2)
-    cucumber-core (1.1.3)
-      gherkin (~> 2.12.0)
-    diff-lcs (1.3)
-    ffi (1.12.2)
-    gherkin (2.12.2)
-      multi_json (~> 1.3)
-    json_pure (2.2.0)
-    multi_json (1.11.0)
-    multi_test (0.1.2)
+    ast (2.4.2)
+    builder (3.2.4)
+    cgi (0.3.2)
+    childprocess (4.1.0)
+    clamp (1.3.2)
+    cucumber (8.0.0)
+      builder (~> 3.2, >= 3.2.4)
+      cucumber-ci-environment (~> 9.0, >= 9.0.4)
+      cucumber-core (~> 11.0, >= 11.0.0)
+      cucumber-cucumber-expressions (~> 15.1, >= 15.1.1)
+      cucumber-gherkin (~> 23.0, >= 23.0.1)
+      cucumber-html-formatter (~> 19.1, >= 19.1.0)
+      cucumber-messages (~> 18.0, >= 18.0.0)
+      diff-lcs (~> 1.5, >= 1.5.0)
+      mime-types (~> 3.4, >= 3.4.1)
+      multi_test (~> 1.1, >= 1.1.0)
+      sys-uname (~> 1.2, >= 1.2.2)
+    cucumber-ci-environment (9.1.0)
+    cucumber-core (11.0.0)
+      cucumber-gherkin (~> 23.0, >= 23.0.1)
+      cucumber-messages (~> 18.0, >= 18.0.0)
+      cucumber-tag-expressions (~> 4.1, >= 4.1.0)
+    cucumber-cucumber-expressions (15.2.0)
+    cucumber-gherkin (23.0.1)
+      cucumber-messages (~> 18.0, >= 18.0.0)
+    cucumber-html-formatter (19.2.0)
+      cucumber-messages (~> 18.0, >= 18.0.0)
+    cucumber-messages (18.0.0)
+    cucumber-tag-expressions (4.1.0)
+    diff-lcs (1.5.0)
+    erb (2.2.3)
+      cgi
+    ffi (1.15.5)
+    json (2.6.2)
+    json_pure (2.6.2)
+    mime-types (3.4.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2022.0105)
+    multi_test (1.1.0)
     open4 (1.3.4)
-    rake (13.0.1)
-    rspec (3.9.0)
-      rspec-core (~> 3.9.0)
-      rspec-expectations (~> 3.9.0)
-      rspec-mocks (~> 3.9.0)
-    rspec-core (3.9.1)
-      rspec-support (~> 3.9.1)
-    rspec-expectations (3.9.0)
+    parallel (1.22.1)
+    parser (3.1.2.1)
+      ast (~> 2.4.1)
+    rainbow (3.1.1)
+    rake (13.0.6)
+    regexp_parser (2.5.0)
+    rexml (3.2.5)
+    rspec (3.11.0)
+      rspec-core (~> 3.11.0)
+      rspec-expectations (~> 3.11.0)
+      rspec-mocks (~> 3.11.0)
+    rspec-core (3.11.0)
+      rspec-support (~> 3.11.0)
+    rspec-expectations (3.11.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
-    rspec-mocks (3.9.1)
+      rspec-support (~> 3.11.0)
+    rspec-mocks (3.11.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
-    rspec-support (3.9.2)
-    rubyzip (2.2.0)
+      rspec-support (~> 3.11.0)
+    rspec-support (3.11.0)
+    rubocop (1.35.1)
+      json (~> 2.3)
+      parallel (~> 1.10)
+      parser (>= 3.1.2.1)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.20.1, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.21.0)
+      parser (>= 3.1.1.0)
+    ruby-progressbar (1.11.0)
+    rubyzip (2.3.2)
+    sys-uname (1.2.2)
+      ffi (~> 1.1)
     text (1.3.1)
+    unicode-display_width (2.2.0)
 
 PLATFORMS
-  ruby
+  x86_64-darwin-21
 
 DEPENDENCIES
-  aruba
+  aruba (~> 0.6.2)
   rake
   rspec
+  rubocop (~> 1.35.1)
   tetra!
 
 BUNDLED WITH
-   1.16.1
+   2.3.21

--- a/lib/tetra/generatable.rb
+++ b/lib/tetra/generatable.rb
@@ -1,5 +1,7 @@
 # encoding: UTF-8
 
+require "erb"
+
 module Tetra
   # adds methods to generate text files from an ERB template
   module Generatable
@@ -10,7 +12,7 @@ module Tetra
 
     # generates content from an ERB template and an object binding
     def generate(template_name, object_binding)
-      erb = ERB.new(File.read(File.join(template_path, template_name)), nil, "<>")
+      erb = ERB.new(File.read(File.join(template_path, template_name)), trim_mode: "<>")
       erb.result(object_binding)
     end
   end

--- a/tetra.gemspec
+++ b/tetra.gemspec
@@ -12,8 +12,6 @@ Gem::Specification.new do |s|
   s.description = "Tetra simplifies the creation of spec files and archives to distribute Java projects in RPM format"
   s.license = "MIT"
 
-  s.rubyforge_project = "tetra"
-
   s.files = `git ls-files`.split("\n")
   s.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }

--- a/tetra.gemspec
+++ b/tetra.gemspec
@@ -1,27 +1,36 @@
-# encoding: UTF-8
 $LOAD_PATH.push File.expand_path("../lib", __FILE__)
 require "tetra/version"
 
 Gem::Specification.new do |s|
-  s.name = "tetra"
-  s.version = Tetra::VERSION
-  s.authors = ["Dominik Gedon", "Silvio Moioli"]
-  s.email = ["dgedon@suse.de"]
-  s.homepage = "https://github.com/uyuni-project/tetra"
-  s.summary = "A tool to package Java projects"
-  s.description = "Tetra simplifies the creation of spec files and archives to distribute Java projects in RPM format"
-  s.license = "MIT"
+  s.name        = "tetra"
+  s.version     = Tetra::VERSION
+  s.authors     = ["Dominik Gedon", "Silvio Moioli"]
+  s.email       = "dgedon@suse.de"
+  s.homepage    = "https://github.com/uyuni-project/tetra"
+  s.summary     = "A tool to package Java projects"
+  s.description = <<-TEXT
+    Tetra simplifies the creation of spec files and archives
+    to distribute Java projects in RPM format
+  TEXT
+  s.license     = "MIT"
+  s.metadata    = {
+    "bug_tracker_uri" => "https://github.com/uyuni-project/tetra/issues",
+    "homepage_uri" => s.homepage,
+    "source_code_uri" => "https://github.com/uyuni-project/tetra"
+  }
 
   s.files = `git ls-files`.split("\n")
   s.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
+  s.add_development_dependency "aruba", "~> 0.6.2"
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"
-  s.add_development_dependency "aruba"
+  s.add_development_dependency "rubocop", "~> 1.35.1"
 
   s.add_runtime_dependency "clamp"
+  s.add_runtime_dependency "erb", "~> 2.2.3"
   s.add_runtime_dependency "json_pure"
   s.add_runtime_dependency "open4"
   s.add_runtime_dependency "rexml"


### PR DESCRIPTION
This PR will update the `tetra.gemspec` and `Gemfile.lock` files to
    

- include missing erb gem and fix usage of `ERB.new()`. See https://github.com/ruby/erb#examples
- add RuboCop as development gem
- add metadata to gemspec
- set explicit aruba gem version before trying to upgrade it
- remove deprecated `rubyforge_project` spec from gemspec

Fixes #52.