### PR TITLE
Add SonarCloud config for automatic analysis

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,4 @@
+# https://docs.sonarcloud.io
+
+sonar.sources=.
+sonar.exclusions=lib/template/bundled/**,spec/data/**


### PR DESCRIPTION
It seems we need this configuration file for the automatic analysis, otherwise the excluded directories defined in the webUI are somehow still included.