### PR TITLE
CI: Adjust dependency review

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,8 +1,6 @@
 name: 'Dependency Review'
 
 on:
-  push:
-    branches: [ master, devel ]
   pull_request:
     branches: [ master, devel ]
 


### PR DESCRIPTION
Only run this action on pull request. This will fix the error that occurs when a PR gets merged.