### PR TITLE
CI: Update Ruby version

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -31,7 +31,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.1'
+        ruby-version: '3.2'
     - name: Install RuboCop
       run: gem install rubocop
     - name: Run RuboCop

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,14 +28,21 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
+        ruby: ['2.7', '3.0', '3.1', '3.2']
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1'
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       - name: Install dependencies
         run: bundle install
       - name: git

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,7 @@ GEM
     unicode-display_width (2.4.2)
 
 PLATFORMS
+  x86_64-darwin-20
   x86_64-darwin-21
   x86_64-darwin-22
   x86_64-linux


### PR DESCRIPTION
This PR 
- updates the Ruby version of the CI RuboCop tetst
- adds a matrix with different OS and Ruby versions for the CI tests