### PR TITLE
CI: Set RuboCop version

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -33,7 +33,7 @@ jobs:
       with:
         ruby-version: '3.2'
     - name: Install RuboCop
-      run: gem install rubocop
+      run: gem install -v 1.57.2 rubocop
     - name: Run RuboCop
       run: |
         rubocop 'bin/tetra'


### PR DESCRIPTION
If we do not set this RuboCop version, it will automatically install the latest one, which lets the test fail due to missing code adjustments for one of the new cops.