### PR TITLE
CI: Add gemspec to RuboCop linting

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -41,3 +41,4 @@ jobs:
         rubocop 'lib/tetra/'
         rubocop 'spec/spec_helper.rb'
         rubocop 'spec/lib'
+        rubocop 'tetra.gemspec'


### PR DESCRIPTION
Apparently the tetra gemspec file is not linted by RuboCop in the CI.