### PR TITLE
CI: Define Ruby version in RuboCop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@ inherit_from: .rubocop_todo.yml
 
 AllCops:
   NewCops: disable
+  TargetRubyVersion: 2.7
 
 Layout/LineLength:
   Max: 140


### PR DESCRIPTION
Otherwise, we see warnings like the following from e.g. Code Climate:

`required_ruby_version` and `TargetRubyVersion` (2.6, which may be specified in .rubocop.yml) should be equal.