### PR TITLE
chore: Update `codecov-action` to 6.0.0.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
           ruby --version
           bundle exec rake
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de  # v5.5.2
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: ./coverage


### PR DESCRIPTION
See https://github.com/codecov/codecov-action/releases. 

Fixes
<img width="1081" height="417" alt="image" src="https://github.com/user-attachments/assets/215e4270-5f19-4119-bb69-f5e89bb1a63e" />
