### PR TITLE
CI: Lock Ruby Gems to verified versions

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -37,8 +37,6 @@ jobs:
       with:
         ruby-version: '3.4'
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-    - name: Install RuboCop via bundle
-      run: bundle install
     - name: Run RuboCop
       run: |
         ruby --version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,8 +45,6 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-      - name: Install dependencies
-        run: bundle install
       - name: git
         run: |
           git config --global user.name "GitHub Actions Bot"


### PR DESCRIPTION
Follows the suggestions from
- https://github.com/uyuni-project/tetra/security/code-scanning/13
- https://github.com/uyuni-project/tetra/security/code-scanning/14

Since there is already the `bundler-cache: true` enabled on `ruby/setup-ruby`, that action automatically runs `bundle install` in strict deployment mode against `Gemfile.lock`.