### PR TITLE
Fix a couple of minor issues

### DIFF
--- a/lib/tetra/facades/process_runner.rb
+++ b/lib/tetra/facades/process_runner.rb
@@ -11,61 +11,18 @@ module Tetra
     def run(commandline, echo = false, stdin_data = nil)
       log.debug "running `#{commandline}`"
 
-      # Prepare buffers to capture output
       out_buffer = StringIO.new
       err_buffer = StringIO.new
-      exit_status = nil
       # Flatten handles nested arrays, Compact removes nils
       cmd_args = Array(commandline).flatten.compact.map(&:to_s)
 
-      Open3.popen3(*cmd_args) do |stdin, stdout, stderr, wait_thr|
-        # 1. Handle Input (if any)
-        stdin.write(stdin_data) if stdin_data
-        stdin.close # Close stdin so the process knows input is finished
+      exit_status = spawn_and_capture(cmd_args, stdin_data, echo, out_buffer, err_buffer)
 
-        # Use threads to read stdout and stderr simultaneously.
-        readers = []
+      out = out_buffer.string
+      err = err_buffer.string
+      raise_execution_failed(commandline, exit_status, out, err) unless exit_status.success?
 
-        readers << Thread.new do
-          stdout.each_line do |line|
-            print line if echo       # Echo to real STDOUT if requested
-            out_buffer << line       # Capture to memory
-          end
-        end
-
-        readers << Thread.new do
-          stderr.each_line do |line|
-            $stderr.print line if echo # Echo to real STDERR if requested
-            err_buffer << line         # Capture to memory
-          end
-        end
-
-        # Wait for reading to finish
-        readers.each(&:join)
-
-        # Get the exit code
-        exit_status = wait_thr.value
-      end
-
-      # Check for failure
-      unless exit_status.success?
-        # Extract strings from buffers
-        out = out_buffer.string
-        err = err_buffer.string
-
-        log.warn("`#{commandline}` failed with status #{exit_status.exitstatus}")
-
-        if !out.empty? || !err.empty?
-          log.warn("Output follows:")
-          log.warn(out) unless out.empty?
-          log.warn(err) unless err.empty?
-        end
-
-        fail ExecutionFailed.new(commandline, exit_status.exitstatus, out, err)
-      end
-
-      # Return the standard output
-      out_buffer.string
+      out
     end
 
     # runs an interactive executable in a subshell
@@ -79,6 +36,48 @@ module Tetra
       log.debug "`#{command}` exited with success #{success}"
 
       fail ExecutionFailed.new(command, $CHILD_STATUS.exitstatus, nil, nil) unless success
+    end
+
+    private
+
+    # spawns commandline, writing stdin and reading stdout/stderr concurrently
+    # (writing stdin to completion before draining stdout/stderr can deadlock
+    # if the child fills its output pipe buffer before consuming all of stdin)
+    # returns the resulting Process::Status
+    def spawn_and_capture(cmd_args, stdin_data, echo, out_buffer, err_buffer)
+      Open3.popen3(*cmd_args) do |stdin, stdout, stderr, wait_thr|
+        threads = [
+          Thread.new { write_stdin(stdin, stdin_data) },
+          Thread.new { pipe_to_buffer(stdout, out_buffer, echo ? $stdout : nil) },
+          Thread.new { pipe_to_buffer(stderr, err_buffer, echo ? $stderr : nil) }
+        ]
+        threads.each(&:join)
+
+        wait_thr.value
+      end
+    end
+
+    def write_stdin(stdin, stdin_data)
+      stdin.write(stdin_data) if stdin_data
+      stdin.close # Close stdin so the process knows input is finished
+    end
+
+    def pipe_to_buffer(io, buffer, echo_io)
+      io.each_line do |line|
+        echo_io&.print(line)
+        buffer << line
+      end
+    end
+
+    def raise_execution_failed(commandline, exit_status, out, err)
+      log.warn("`#{commandline}` failed with status #{exit_status.exitstatus}")
+      if !out.empty? || !err.empty?
+        log.warn("Output follows:")
+        log.warn(out) unless out.empty?
+        log.warn(err) unless err.empty?
+      end
+
+      fail ExecutionFailed.new(commandline, exit_status.exitstatus, out, err)
     end
   end
 

--- a/lib/tetra/maven_website.rb
+++ b/lib/tetra/maven_website.rb
@@ -77,7 +77,9 @@ module Tetra
         when Net::HTTPSuccess
           response.body
         when Net::HTTPRedirection
-          location = response["location"]
+          # Location may be relative (RFC 7231); resolve it against the
+          # current URI so relative redirects don't crash Net::HTTP.start.
+          location = (uri + response["location"]).to_s
           log.info("Redirected to #{location}")
           # Recursive call to follow redirect (params are usually part of the new URL)
           fetch(location, {}, limit - 1)

--- a/lib/tetra/packages/scriptable.rb
+++ b/lib/tetra/packages/scriptable.rb
@@ -44,8 +44,5 @@ module Tetra
 
       cmds
     end
-
-    # Alias for backward compatibility if other classes call 'aliases'
-    alias aliases generate_aliases
   end
 end

--- a/lib/tetra/pom_getter.rb
+++ b/lib/tetra/pom_getter.rb
@@ -23,7 +23,9 @@ module Tetra
       log.debug("Attempting unpack of #{file} to find a POM")
       begin
         Zip::File.foreach(file) do |entry|
-          # Security check (Zip Slip)
+          # Defense in depth against malicious entry names. Note this method
+          # never extracts entries to disk (only reads pom.xml into memory),
+          # so Zip Slip path traversal is not actually reachable here.
           next if entry.name.include?("..") || entry.name.start_with?("/")
 
           # PERFORMANCE: end_with? is much faster than Regexp for simple suffixes


### PR DESCRIPTION
  Summary of changes:
  - `lib/tetra/facades/process_runner.rb`: `run` now writes stdin and reads stdout/stderr concurrently (each in its own thread) instead of writing stdin to completion first, removing the deadlock risk.  `stdin.write(stdin_data)` runs to completion before the stdout/stderr reader threads are started. If a child fills its stdout/stderr pipe buffer before draining stdin, you get a classic parent-writes/child-writes deadlock. Extracted into `spawn_and_capture` private helpers to keep run under the `Metrics/AbcSize` RuboCop limit.
  - `lib/tetra/packages/scriptable.rb`: removed the dead alias aliases generate_aliases (no callers anywhere in the codebase).
  - `lib/tetra/maven_website.rb`: redirect handling now resolves Location against the current URI (uri + `response["location"]`) instead of assuming it's absolute.
  - `lib/tetra/pom_getter.rb`: corrected the misleading "Zip Slip" comment to reflect that this method only reads entries into memory and never extracts to disk — the guard is defense in depth, not a path-traversal fix.